### PR TITLE
Use Jinja loader to get markdown template content

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,2 +1,3 @@
 v0.1.0, 2019-06-14 -- Basic Flask module extracted from canonical.com codebase
 v0.1.1, 2019-06-18 -- Add README to pypi
+v0.1.2, 2019-06-28 -- Allow the view to work if you specify a relative templates path

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.templatefinder",
-    version="0.1.1",
+    version="0.1.2",
     author="Canonical Webteam",
     url="https://github.com/canonical-webteam/templatefinder",
     packages=find_packages(),


### PR DESCRIPTION
## Done
Changed the view to use the template loader to load template files contents. This allows us to set a relative template path when setting up our flask apps.