### PR TITLE
Run markdown file contents through template parser

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,3 +2,4 @@ v0.1.0, 2019-06-14 -- Basic Flask module extracted from canonical.com codebase
 v0.1.1, 2019-06-18 -- Add README to pypi
 v0.1.2, 2019-06-28 -- Allow the view to work if you specify a relative templates path
 v0.2.0, 2019-08-29 -- Fix "context" and "markdown_includes" in Markdown files
+v0.2.1, 2019-09-03 -- Run Markdown file contents through template parser

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.templatefinder",
-    version="0.2.0",
+    version="0.2.1",
     author="Canonical Webteam",
     url="https://github.com/canonical-webteam/templatefinder",
     packages=find_packages(),


### PR DESCRIPTION
This is how the old [Django TemplateFinder](https://github.com/canonical-web-and-design/canonicalwebteam.django-views/blob/master/canonicalwebteam/django_views/__init__.py#L150) used to work

Helps with https://github.com/canonical-web-and-design/ubuntu.com/issues/5743