### PR TITLE
v0.2.2: Run markdown_includes through template parser

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,3 +3,4 @@ v0.1.1, 2019-06-18 -- Add README to pypi
 v0.1.2, 2019-06-28 -- Allow the view to work if you specify a relative templates path
 v0.2.0, 2019-08-29 -- Fix "context" and "markdown_includes" in Markdown files
 v0.2.1, 2019-09-03 -- Run Markdown file contents through template parser
+v0.2.2, 2019-09-05 -- Run markdown_includes through the templater parser

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.templatefinder",
-    version="0.2.1",
+    version="0.2.2",
     author="Canonical Webteam",
     url="https://github.com/canonical-webteam/templatefinder",
     packages=find_packages(),


### PR DESCRIPTION
This will help with https://github.com/canonical-web-and-design/ubuntu.com/issues/5767 when it finds its way into ubuntu.com in https://github.com/canonical-web-and-design/ubuntu.com/pull/5770.

QA
--

Go to the demo at https://ubuntu-com-canonical-web-and-design-pr-5770.run.demo.haus/legal/ubuntu-advantage-service-description, check there's no ugly variable below the table.