### PR TITLE
v0.2.3: Add IDs to generated heading markup

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,3 +4,4 @@ v0.1.2, 2019-06-28 -- Allow the view to work if you specify a relative templates
 v0.2.0, 2019-08-29 -- Fix "context" and "markdown_includes" in Markdown files
 v0.2.1, 2019-09-03 -- Run Markdown file contents through template parser
 v0.2.2, 2019-09-05 -- Run markdown_includes through the templater parser
+v0.2.3, 2020-01-29 -- Add IDs to headings

--- a/canonicalwebteam/templatefinder/templatefinder.py
+++ b/canonicalwebteam/templatefinder/templatefinder.py
@@ -1,12 +1,13 @@
 # Standard library
 import os
+import re
 
 # Packages
 import flask
 from flask.views import View
 from frontmatter import loads as load_frontmatter_from_markdown
 from jinja2.exceptions import TemplateNotFound
-from mistune import Markdown, BlockLexer
+from mistune import Markdown, BlockLexer, Renderer
 
 
 class WebteamBlockLexer(BlockLexer):
@@ -25,6 +26,22 @@ class WebteamBlockLexer(BlockLexer):
     )
 
 
+class IDRenderer(Renderer):
+    def header(self, text, level, raw=None):
+        header_id = (text.replace(" ", "-")).lower()
+        header_id = re.sub("[^\w-]", "", header_id)
+        header_id = re.sub('<[^<]+?>', '', header_id)
+
+        text = "<h{} id={}>{}</h{}>".format(
+            level,
+            header_id,
+            text,
+            level
+        )
+
+        return text
+
+
 class TemplateFinder(View):
     """
     A TemplateView that guesses the template name based on the
@@ -36,6 +53,7 @@ class TemplateFinder(View):
             parse_block_html=True,
             parse_inline_html=True,
             block=WebteamBlockLexer(),
+            renderer=IDRenderer()
         )
 
     def dispatch_request(self, *args, **kwargs):

--- a/canonicalwebteam/templatefinder/templatefinder.py
+++ b/canonicalwebteam/templatefinder/templatefinder.py
@@ -29,17 +29,11 @@ class WebteamBlockLexer(BlockLexer):
 class IDRenderer(Renderer):
     def header(self, text, level, raw=None):
         header_id = (text.replace(" ", "-")).lower()
-        header_id = re.sub("[^\w-]", "", header_id)
-        header_id = re.sub('<[^<]+?>', '', header_id)
+        header_id = re.sub(r"<[^<]+?>", "", header_id)
+        header_id = re.sub(r"&[\w\d]+;", "", header_id)
+        header_id = re.sub(r"[^\w-]", "", header_id)
 
-        text = "<h{} id={}>{}</h{}>".format(
-            level,
-            header_id,
-            text,
-            level
-        )
-
-        return text
+        return f'<h{level} id="{header_id}">{text}</h{level}>'
 
 
 class TemplateFinder(View):
@@ -53,7 +47,7 @@ class TemplateFinder(View):
             parse_block_html=True,
             parse_inline_html=True,
             block=WebteamBlockLexer(),
-            renderer=IDRenderer()
+            renderer=IDRenderer(),
         )
 
     def dispatch_request(self, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -20,4 +20,5 @@ setup(
         "python-frontmatter>=0.4.5",
         "bleach>=3.1",
     ],
+    tests_require=["Flask-Testing>=0.7.1"],
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.templatefinder",
-    version="0.2.2",
+    version="0.2.3",
     author="Canonical Webteam",
     url="https://github.com/canonical-webteam/templatefinder",
     packages=find_packages(),

--- a/tests/fixtures/special-chars-test.md
+++ b/tests/fixtures/special-chars-test.md
@@ -1,0 +1,5 @@
+---
+wrapper_template: 'markdown_wrapper.html'
+---
+
+# <code>&lt;h1&gt;</code> with 'special' chars

--- a/tests/test_templatefinder.py
+++ b/tests/test_templatefinder.py
@@ -41,14 +41,33 @@ class TestTemplateFinder(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.data,
-            b"<h1>MARKDOWN</h1>\n<h1>This is a markdown heading</h1>\n",
+            (
+                b"<h1>MARKDOWN</h1>\n"
+                b'<h1 id="this-is-a-markdown-heading">'
+                b"This is a markdown heading</h1>"
+            ),
         )
 
     def test_getting_nested_markdown(self):
         response = self.client.get("/nested/test")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.data, b"<h1>MARKDOWN</h1>\n<h1>This is a nested</h1>\n"
+            response.data,
+            (
+                b'<h1>MARKDOWN</h1>\n<h1 id="this-is-a-nested">'
+                b"This is a nested</h1>"
+            ),
+        )
+
+    def test_heading_id_with_special_chars(self):
+        response = self.client.get("/special-chars-test")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data,
+            (
+                b'<h1>MARKDOWN</h1>\n<h1 id="h1-with-special-chars">'
+                b"<code>&lt;h1&gt;</code> with 'special' chars</h1>"
+            ),
         )
 
     def test_get_markdown_with_missing_wrapper_metadata(self):


### PR DESCRIPTION
Fixes #9

QA
--

Run this branch: https://github.com/canonical-web-and-design/vanilla-framework/pull/2792

Go to base/typography/ and see the in-page links work