### PR TITLE
WIP: Use mistune v2

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,3 +6,4 @@ v0.2.1, 2019-09-03 -- Run Markdown file contents through template parser
 v0.2.2, 2019-09-05 -- Run markdown_includes through the templater parser
 v0.2.3, 2020-01-29 -- Add IDs to headings
 v0.2.4, 2020-01-29 -- Call IDRenderer with appropriate arguments
+v0.3.0, 2020-02-28 -- Use mistune v2

--- a/canonicalwebteam/templatefinder/templatefinder.py
+++ b/canonicalwebteam/templatefinder/templatefinder.py
@@ -7,27 +7,11 @@ import flask
 from flask.views import View
 from frontmatter import loads as load_frontmatter_from_markdown
 from jinja2.exceptions import TemplateNotFound
-from mistune import Markdown, BlockLexer, Renderer
+from mistune import create_markdown, BlockParser, HTMLRenderer
 
 
-class WebteamBlockLexer(BlockLexer):
-    list_rules = (
-        "newline",
-        "block_code",
-        "fences",
-        "lheading",
-        "hrule",
-        "table",
-        "nptable",
-        "block_quote",
-        "list_block",
-        "block_html",
-        "text",
-    )
-
-
-class IDRenderer(Renderer):
-    def header(self, text, level, raw=None):
+class TemplateFinderHTMLRenderer(HTMLRenderer):
+    def heading(self, text, level, raw=None):
         header_id = (text.replace(" ", "-")).lower()
         header_id = re.sub(r"<[^<]+?>", "", header_id)
         header_id = re.sub(r"&[\w\d]+;", "", header_id)
@@ -43,9 +27,10 @@ class TemplateFinder(View):
     """
 
     def __init__(self):
-        self.markdown_parser = Markdown(
-            block=WebteamBlockLexer(),
-            renderer=IDRenderer(parse_block_html=True, parse_inline_html=True),
+        self.markdown_parser = create_markdown(
+            escape=True,
+            renderer=TemplateFinderHTMLRenderer(),
+            plugins=['footnotes', 'strikethrough', 'table', 'url'],
         )
 
     def dispatch_request(self, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.templatefinder",
-    version="0.2.4",
+    version="0.3.0",
     author="Canonical Webteam",
     url="https://github.com/canonical-webteam/templatefinder",
     packages=find_packages(),
@@ -16,7 +16,8 @@ setup(
     long_description_content_type="text/markdown",
     install_requires=[
         "Flask>=1.0",
-        "mistune>=0.8.4",
+        "werkzeug<=0.16"
+        "mistune>=2.0.0a2",
         "python-frontmatter>=0.4.5",
         "bleach>=3.1",
     ],


### PR DESCRIPTION
There is now a v2 of mistune, that make customizing rendering of markdown quite neat by using plugins. But to make use of v2 we need to update this project first, to avoid conflicts.

Page failing **miserably** while using this version
- ubuntu.com/kubernetes/docs