### PR TITLE
Ignore underscore in url

### DIFF
--- a/canonicalwebteam/templatefinder/templatefinder.py
+++ b/canonicalwebteam/templatefinder/templatefinder.py
@@ -110,6 +110,12 @@ class TemplateFinder(View):
         Given a basic path, find an HTML or Markdown file
         """
 
+        # If on part of the url has _ this means the accessed
+        # file is a partial
+        for url_part in url_path.split("/"):
+            if url_part.startswith("_"):
+                return None
+
         # Try to match HTML or Markdown files
         if self._template_exists(url_path + ".html"):
             return url_path + ".html"

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.templatefinder",
-    version="0.2.4",
+    version="0.2.5",
     author="Canonical Webteam",
     url="https://github.com/canonical-webteam/templatefinder",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     long_description_content_type="text/markdown",
     install_requires=[
         "Flask>=1.0",
-        "mistune>=0.8.4",
+        "mistune==0.8.4",
         "python-frontmatter>=0.4.5",
         "bleach>=3.1",
     ],


### PR DESCRIPTION
# Done

Fixes #14 
If a url contains a _ at the start of one of its part then 404 since it's a include file

```
/_bla/bla      -> no
/_bla/_bla    -> no
/bla/_bla      -> no
/bla_/bla      -> yes
/bla/bla_      -> yes
/bla/bla        -> yes
```

# QA 

- Pull https://github.com/canonical-web-and-design/vanilla-framework
- replace the template finder module with this branch
- `git+git://github.com/tbille/canonicalwebteam.templatefinder@ignore-underscore#egg=canonicalwebteam.templatefinder`
- `./run`
- http://127.0.0.1:5000/_layouts/docs -> 404