### PR TITLE
Fix repo URL in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name="canonicalwebteam.templatefinder",
     version="1.0.0",
     author="Canonical Webteam",
-    url="https://github.com/canonical-webteam/templatefinder",
+    url="https://github.com/canonical-web-and-design/canonicalwebteam.templatefinder",
     packages=find_packages(),
     description=(
         "A module which attempts to load the corresponding templates directly"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,10 @@ setup(
     name="canonicalwebteam.templatefinder",
     version="1.0.0",
     author="Canonical Webteam",
-    url="https://github.com/canonical-web-and-design/canonicalwebteam.templatefinder",
+    url=(
+        "https://github.com/canonical-web-and-design/",
+        "canonicalwebteam.templatefinder",
+    ),
     packages=find_packages(),
     description=(
         "A module which attempts to load the corresponding templates directly"


### PR DESCRIPTION
This was linking to an old inactive URL.

BTW: Needs some adjustments, as I don't know how to make it not fail on line length limit… Split the URL into 2 lines?